### PR TITLE
Add Item model

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,26 @@
+# {Item} is a standardized data point
+#
+# Example
+#   Item.new(name: "Thing", value: 123)
+class Item
+  ATTRS = %i(name value)
+
+  attr_reader(*ATTRS)
+
+  def initialize(**attrs)
+    ATTRS.each do |attr|
+      next unless attrs.key?(attr)
+      send(:"#{attr}=", attrs.fetch(attr))
+    end
+  end
+
+  def as_json(*)
+    ATTRS.each_with_object({}) do |attr, obj|
+      obj[attr.to_s] = public_send(attr)
+    end
+  end
+
+  private
+
+  attr_writer(*ATTRS)
+end


### PR DESCRIPTION
Vi skapade en `Item` model som ett alternativ till att ha bara en hash.
Tänker att det är vårt ansvar att köra `.to_json` på den sedan. Låter det vettigt? @KevinSjoberg @davidelbe.

Vi har mockat så här tillsvidare när vi utvecklar charts.
```ruby
class ChartsController < ApplicationController
  def show
    @data = [
      Item.new(name: 'Foo', value: 123),
      Item.new(name: 'Bar', value: 57),
      Item.new(name: 'Baz', value: 7)
    ]
    render "charts/#{params[:type]}"
  end
end
```
```
<%= @data.to_json %>
```