### PR TITLE
Remove RAILS_ENV for precompile

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -18,7 +18,7 @@ run.config:
 
 deploy.config:
   extra_steps:
-    - rake assets:precompile RAILS_ENV=production
+    - rake assets:precompile
   before_live:
     web.main:
       - rails db:create


### PR DESCRIPTION
We don't need to set rails environment for precompilation since it's stored in the container anyway.